### PR TITLE
[12.0][ADD] housing_cooperative_base: automatical renewal of contracts

### DIFF
--- a/housing_cooperative_base/__manifest__.py
+++ b/housing_cooperative_base/__manifest__.py
@@ -13,6 +13,7 @@
     "license": "AGPL-3",
     "depends": [
         "base",
+        "mail",
         "contacts",
         "contract",
         "contract_sale",

--- a/housing_cooperative_base/data/cron.xml
+++ b/housing_cooperative_base/data/cron.xml
@@ -17,7 +17,7 @@
             <field name="name">Automatic Lease Renewal</field>
             <field name="model_id" ref="model_hc_lease"/>
             <field name="state">code</field>
-            <field name="code">model.cron_automatic_renewal()</field>
+            <field name="code">model.cron_do_automatic_renewal()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
             <field name="nextcall" eval="(datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d 03:00:00')"/>

--- a/housing_cooperative_base/data/cron.xml
+++ b/housing_cooperative_base/data/cron.xml
@@ -12,4 +12,17 @@
             <field name="doall">False</field>
         </record>
     </data>
+    <data noupdate="1">
+        <record forcecreate="True" id="ir_cron_automatic_lease_renewal" model="ir.cron">
+            <field name="name">Automatic Lease Renewal</field>
+            <field name="model_id" ref="model_hc_lease"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_automatic_renewal()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="nextcall" eval="(datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d 03:00:00')"/>
+            <field name="numbercall">-1</field>
+            <field name="doall">False</field>
+        </record>
+    </data>
 </odoo>

--- a/housing_cooperative_base/demo/demo.xml
+++ b/housing_cooperative_base/demo/demo.xml
@@ -135,8 +135,8 @@
 
         <record id="demo_lease_1" model="hc.lease">
             <field name="tenant_id" ref="res_partner_cooperator_1_demo"/>
-            <field name="start">2017-09-21</field>
-            <field name="expected_end">2020-09-21</field>
+            <field name="start">2017-09-01</field>
+            <field name="expected_end">2020-08-31</field>
             <field name="rent">2000</field>
             <field name="charges">200</field>
             <field name="deposit">4000</field>
@@ -147,8 +147,8 @@
         </record>
         <record id="demo_lease_2" model="hc.lease">
              <field name="tenant_id" ref="res_partner_cooperator_5_demo"/>
-            <field name="start">2018-09-20</field>
-            <field name="expected_end">2021-09-20</field>
+            <field name="start">2018-09-01</field>
+            <field name="expected_end">2021-08-31</field>
             <field name="rent">500</field>
             <field name="charges">100</field>
             <field name="deposit">1000</field>
@@ -176,9 +176,9 @@
 
         <record id="demo_lease_3" model="hc.lease">
             <field name="tenant_id" ref="res_partner_cooperator_6_demo"/>
-            <field name="start">2014-10-20</field>
-            <field name="expected_end">2018-12-20</field>
-            <field name="effective_end">2018-09-01</field>
+            <field name="start">2014-10-31</field>
+            <field name="expected_end">2018-12-31</field>
+            <field name="effective_end">2018-09-30</field>
             <field name="rent">1800</field>
             <field name="charges">210</field>
             <field name="deposit">2500</field>

--- a/housing_cooperative_base/models/lease.py
+++ b/housing_cooperative_base/models/lease.py
@@ -380,7 +380,7 @@ class Lease(models.Model):
         return self.env["account.journal"].search(domain, limit=1)
 
     @api.multi
-    def _automatic_renewal(self):
+    def _do_automatic_renewal(self):
         for lease in self:
             if (
                 lease.state == "ongoing"
@@ -401,7 +401,7 @@ class Lease(models.Model):
                     )
 
     @api.model
-    def cron_automatic_renewal(self):
+    def cron_do_automatic_renewal(self):
         _logger.info("Executing: automatic renewal of leases")
         leases = self.search([])
-        leases._automatic_renewal()
+        leases._do_automatic_renewal()

--- a/housing_cooperative_base/views/lease.xml
+++ b/housing_cooperative_base/views/lease.xml
@@ -42,6 +42,8 @@
                             <field name="start"/>
                             <field name="expected_end"/>
                             <field name="effective_end"/>
+                            <field name="automatic_renewal"/>
+                            <field name="automatic_renewal_months"/>
                             <field name="note"/>
                         </group>
                         <group>
@@ -89,6 +91,11 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="activity_ids" widget="mail_activity"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
- Auto renew leases with cron
- Log changes to dates in chatter
- Push these changes to contract

At the end of this development, I discovered that renewal is implemented for contracts. It would thus be an option to rewrite this and:
- Push the lease's `automatic_renewal` and `automatic_renewal_months` to the contract's `is_auto_renew` and `auto_renew_interval`
- Instead of checking at the lease level if a renewal is due, checking this at the contract level, and in case of renewal, bringing the contract's new end date back to the lease
- For the renewal itself: using the contract's 'renewal()' function (which terminates a contract line and creates a new follow up contract line (!) ) instead of just adapting the contract lines' end dates as is the case now.
- Disallowing manual modification of the lease end date in case the contract ended, and providing.
- Adding a manual 'renew' button on the lease? Otherwise I sens there could be cases where you can't modify the end date, but the contract is not closed. To check...

Opinion @robinkeunen ?
