### PR TITLE
[12.0][ADD] housing_cooperative_base: show inhabitant leases and coinhabitants

### DIFF
--- a/housing_cooperative_base/models/res_partner.py
+++ b/housing_cooperative_base/models/res_partner.py
@@ -61,7 +61,24 @@ class ResPartner(models.Model):
         comodel_name="hc.lease", compute="_compute_lease_dates"
     )
     lease_ids = fields.One2many(
-        comodel_name="hc.lease", inverse_name="tenant_id", string="Leases"
+        comodel_name="hc.lease",
+        inverse_name="tenant_id",
+        string="Leases as Tenant",
+    )
+    lease_signatory_ids = fields.Many2many(
+        comodel_name="hc.lease",
+        string="Leases as Signatory",
+        relation="hc_lease_signatory_ids_rel",
+    )
+    lease_inhabitant_ids = fields.Many2many(
+        comodel_name="hc.lease",
+        string="Leases as Inhabitant",
+        relation="hc_lease_inhabitant_ids_rel",
+    )
+    co_inhabitant_ids = fields.Many2many(
+        comodel_name="res.partner",
+        string="Co-Inhabitants",
+        compute="_compute_co_inhabitant_ids",
     )
 
     attachment_number = fields.Integer(
@@ -109,6 +126,16 @@ class ResPartner(models.Model):
                 )
             else:
                 partner.age = False
+
+    @api.multi
+    @api.depends("lease_inhabitant_ids.inhabitant_ids")
+    def _compute_co_inhabitant_ids(self):
+        for partner in self:
+            co_inhabitant_ids = partner.lease_inhabitant_ids.mapped(
+                "inhabitant_ids"
+            )
+            co_inhabitant_ids -= partner
+            partner.co_inhabitant_ids = co_inhabitant_ids
 
     @api.multi
     def _get_attachment_number(self):

--- a/housing_cooperative_base/views/res_partner.xml
+++ b/housing_cooperative_base/views/res_partner.xml
@@ -46,14 +46,23 @@
             <xpath expr="//field[@name='child_ids']/.." position="before">
                 <page name="leases" string="Leases" autofocus="autofocus">
                     <group>
-                        <field name="lease_ids" nolabel="1" context="{'default_tenant_id': id}">
+                        <field name="lease_inhabitant_ids" nolabel="1" context="{'default_tenant_id': id}">
                             <tree>
                                 <field name="name"/>
+                                <field name="tenant_id"/>
+                                <field name="signatory_ids" widget="many2many_tags"/>
+                                <field name="inhabitant_ids" widget="many2many_tags"/>
                                 <field name="start"/>
                                 <field name="end"/>
                                 <field name="state"/>
                             </tree>
                         </field>
+                    </group>
+                    <h4>Co-Inhabitants</h4>
+                    <group>
+                        <group>
+                            <field name="co_inhabitant_ids" mode="kanban" no_create="1" nolabel="1"/>
+                        </group>
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
On partner models:
- Add field of all leases where partner is signatory (note for this `lease_signatory_ids` field the options `relation=hc_lease_signatory_ids_rel` is able to use the same table name as the inversie field `signatory_ids` defined on leases!)
- Add field of all leases where partner is inhabitant
- Add field of all coinhabitants

On partner views:
- Show list of leases where partner is inhabitant (would it be possible to directly click through to the inhabitants here?)
- Show kanban of coinhabitants